### PR TITLE
Update version 2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.1.1
+- Update native dependency to `pushe:2.1.0`
+- Fix issue with Firebase cloud message v20.1.1 or higher
+- Fix bug with RxJava2
+
 ## 2.1.0
 
 - Added Support for Android Embedded V2
@@ -12,7 +17,6 @@
 - Fix bug when clearing `customId`, `userEmail` and `userPhoneNumber`. You can now set null to clear them.
 
 ## 2.0.3
-
 - Fix bug in notification listeners
 - Improve `sendNotificationToUser` to support multiple IDs
 - Function callbacks will have no boolean status anymore, since there was no false status
@@ -20,26 +24,21 @@
 - Example project improvements
 
 ## 2.0.2
-
 - Fix issue with AndroidX
 
 ## 2.0.1
-
 - Fix formatting of plugin
 - Minor improvements
 
 ## 2.0.0
-
 * Migrate to the new Plus sdk of Pushe
 * Get used of new Plus features in the SDK
 * No initialization is needed for the library
 > Notice the `setNotificationListener` is not fully reliable yet, since it does not handle background
 
 ## 1.1.0-alpha1
-
 * Fixed Battery usage issue
 * Added method `isNotificationOn`
-
 ## 1.0.1
 
 * Fix problem with AndroidX projects.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pushe flutter
 
-A plugin to use Pushe sdk in Flutter framework.
+[Pushe](https://pushe.co) notification service official plugin for Flutter.
 
 ## Installation
 
@@ -8,7 +8,7 @@ Add the plugin to `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  pushe_flutter: 2.1.0
+  pushe_flutter: 2.1.1
 ```
 * If you want to use the latest version, not necessarily released, you can use the github source code.
 
@@ -42,4 +42,5 @@ import 'package:pushe_flutter/pushe.dart';
 ## More Info
 
 * For more details, visit [HomePage docs](https://docs.pushe.co/)
+* FAQ and issues in [Github repo](https://github.com/pusheco/pushe-flutter/issues?q=is%3Aissue+).
 * Sample project is in the library source code and in the [Sample repo on github](https://github.com/pusheco/pushe-flutter-sample)

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -43,7 +43,10 @@ android {
 }
 
 dependencies {
-    implementation ("co.pushe.plus:base:2.0.4")
+    implementation ("co.pushe.plus:base:2.1.0") {
+        exclude(group: 'co.pushe.plus', module:'rxjava')
+    }
+    implementation("io.reactivex.rxjava2:rxjava:2.2.9")
     api "androidx.multidex:multidex:2.0.1"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pushe_flutter
 description: Pushe push notification SDK implementation for Flutter framework, for Android and iOS
-version: 2.1.0
+version: 2.1.1
 homepage: https://pushe.co
 
 environment:


### PR DESCRIPTION
## Changes for 2.1.1
- Update native dependency to `pushe:2.1.0`
    - Native library has migrated to AndroidX
    - Some bug fixes and improvements
- Fix issue with Firebase cloud message v20.1.1 or higher
- Fix bug with RxJava2